### PR TITLE
Pagination and blog preview pages

### DIFF
--- a/src/components/blog-posts/Pagination.js
+++ b/src/components/blog-posts/Pagination.js
@@ -1,0 +1,38 @@
+import React from "react";
+import { Link } from "gatsby";
+
+const Pagination = ({ numPages, currentPage }) => {
+    var pageArray = [];
+    for(var i=1; i <= numPages; i++){
+        pageArray[i] = i;
+        return (
+            <div>
+                <ul>
+                    {currentPage !== 1 && (
+                        <li>
+                            <Link to={currentPage === 2 ? "/blog": `/blog/${currentPage-1}`}>
+                                Previous
+                            </Link>
+                        </li>
+                    )}
+                    {pageArray.map((pageNum) => (
+                        <li key={`pageNum_${pageNum}`}>
+                            <Link to={pageNum === 1 ? "/blog": `/blog/${pageNum}`}>
+                                {pageNum}
+                            </Link>
+                        </li>
+                    ))}
+                    {currentPage !== numPages && (
+                        <li>
+                            <Link to={`/blog/${currentPage + 1}`}>
+                                Next
+                            </Link>
+                        </li>
+                    )}
+                </ul>
+            </div>
+        );
+    };
+};
+
+export default Pagination;

--- a/src/templates/blog-preview.js
+++ b/src/templates/blog-preview.js
@@ -1,0 +1,56 @@
+import React from "react";
+import { graphql, Link } from "gatsby";
+import Layout  from "../components/layout/Layout.js";
+import Pagination from "../components/blog-posts/Pagination";
+import TagList from "../components/blog-posts/TagList";
+
+export default function BlogPreview({pageContext, data }){
+    //destructuring pageContext and data to access numPages, CurrentPage and nodes respectively
+    const {numPages, currentPage} = pageContext;
+    const {blogposts: {nodes},} = data;
+    
+    return(
+        <Layout>
+            <div className="max-w-5xl mx-auto space-y-8 py-6 md:py-12">
+                {/* data from each post */}
+                {nodes.map(({frontmatter: {date, tags, title, desc}, fields: {slug}}) => (
+                    <div>
+                        <Link to={ `/blog${slug}`}>
+                            <h2 className="text-2xl font-medium">{title}</h2>
+                            <div className="flex items-center space-x-2">
+                                <p className="text-lg opacity-50">{date.split("T")[0]}</p>
+                                <TagList tags={tags} />
+                            </div>
+                            <p>{desc}</p>
+                        </Link>
+                    </div>
+    
+                ))}
+                <Pagination numPages={numPages} currentPage={currentPage} />
+            </div>
+        </Layout>
+    );
+};
+
+export const pageQuery = graphql`
+    query($skip: Int!, $limit: Int!){
+        blogposts: allMdx(
+            limit: $limit
+            skip: $skip
+            filter: {frontmatter: { type: { eq: "Blog" }}}
+            sort: { fields: frontmatter___date, order: DESC }
+        ) {
+            nodes{
+                frontmatter{
+                    date
+                    title
+                    tags
+                    desc
+                }
+                fields{
+                    slug
+                }
+            }
+        }
+    }
+`;


### PR DESCRIPTION
Created pagination and blog preview pages which contain the pagination within the page at the bottom of all the blog preview posts.

- gatsby-node.js : used to create the blog preview page  setting the limit to the amount of blog posts previews per page and setting the number of pages needed to create those blog posts previews.
-  pagination.js: The pagination component which adds numerical pointers which link to certain pages, with the back and next option.
- blog-preview.js :  the blog preview template  which pulls and injects blog posts data to display the date, tags, title, and description of the posts.